### PR TITLE
Format/Layout issue in web.config docs

### DIFF
--- a/src/docs/web.config/index.html
+++ b/src/docs/web.config/index.html
@@ -116,7 +116,9 @@
 
 <p><strong>8. Proper SVG Serving</strong></p>
 
-<pre><code><span class="tag">&lt;mimeMap</span><span class="pln"> </span><span class="atn">fileExtension</span><span class="pun">=</span><span class="atv">".svg"</span><span class="pln"> </span><span class="atn">mimeType</span><span class="pun">=</span><span class="atv">"images/svg+xml"</span><span class="pln"> </span><span class="tag">/&gt;</span><span class="pln"><br /></span><span class="tag">&lt;mimeMap</span><span class="pln"> </span><span class="atn">fileExtension</span><span class="pun">=</span><span class="atv">".svgz"</span><span class="pln"> </span><span class="atn">mimeType</span><span class="pun">=</span><span class="atv">"images/svg+xml"</span><span class="pln"> </span><span class="tag">/&gt;</span><span class="pln"><br /><br />Required for SVG Webfonts on iPad <br /></span></code></pre>
+<pre><code><span class="tag">&lt;mimeMap</span><span class="pln"> </span><span class="atn">fileExtension</span><span class="pun">=</span><span class="atv">".svg"</span><span class="pln"> </span><span class="atn">mimeType</span><span class="pun">=</span><span class="atv">"images/svg+xml"</span><span class="pln"> </span><span class="tag">/&gt;</span><span class="pln"><br /></span><span class="tag">&lt;mimeMap</span><span class="pln"> </span><span class="atn">fileExtension</span><span class="pun">=</span><span class="atv">".svgz"</span><span class="pln"> </span><span class="atn">mimeType</span><span class="pun">=</span><span class="atv">"images/svg+xml"</span><span class="pln"> </span><span class="tag">/&gt;</span><span class="pln"><br /></span></code></pre>
+
+<p>Required for SVG Webfonts on iPad.</p>
 
 <p><strong>9. HTML4 Web font MIMEtypes</strong></p>
 


### PR DESCRIPTION
The 'Proper SVG Serving' section of the web.config docs had some text at the end of the code example that should have been included outside of the code section.
