### PR TITLE
Minor typo

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -82,7 +82,7 @@
         <i>{% blocktrans %}or{% endblocktrans %}</i>
         <span><a href="http://github.com/h5bp/html5-boilerplate/zipball/v2.0stripped">{% blocktrans %}<u>Download</u> Boilerplate "stripped"{% endblocktrans %}</a> <small>{% blocktrans %}No comments, just the bizniss.{% endblocktrans %}</small></span>
         <i>{% blocktrans %}or{% endblocktrans %}</i>        
-        <span><a id="builder-custom" href="#builder">{% blocktrans %}<u>Customize</u> Boilerplate{% endblocktrans %}</a> <small>{% blocktrans %}100&percnt; hipster.{% endblocktrans %}</small></span>        
+        <span><a id="builder-custom" href="#builder">{% blocktrans %}<u>Customize</u> Boilerplate{% endblocktrans %}</a> <small>{% blocktrans %}100&#37; hipster.{% endblocktrans %}</small></span>        
       </p>
       <div class="focus">
         <div id="builder">     


### PR DESCRIPTION
&percnt; renders &percnt; and does not render "%" in IE (fine in all others).  Given cross-browser awareness/sensitivity minor change seems worth it.
