### PR TITLE
/mobile to /mobile/ redirection to fix bug

### DIFF
--- a/src/.htaccess
+++ b/src/.htaccess
@@ -31,6 +31,14 @@
   RewriteRule ^ http://%1%{REQUEST_URI} [R=301,L]
 </IfModule>
 
+# Fix /mobile bug
+# Rewrite "/mobile -> /mobile/"
+<IfModule mod_rewrite.c>
+  RewriteEngine On
+  RewriteBase /
+  RewriteRule ^mobile$ mobile/ [R=301,L]
+</IfModule>
+
 # ???
 order allow,deny
 deny from 90.168.89.100


### PR DESCRIPTION
Redirects `http://html5boilerplate.com/mobile` (which had redirection issues) to `http://html5boilerplate.com/mobile/`, which displays correctly, using `.htaccess` `mod_rewrite`.

Addresses issue https://github.com/h5bp/html5boilerplate.com/issues/99
