### PR TITLE
Add grunt-uncss.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.tmp
 dist
 node_modules
 validation-report.json

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -25,12 +25,12 @@ module.exports = function (grunt) {
 
         autoprefixer: {
             options: {
-                browsers: ['last 2 version', 'ie 6', 'ie 7', 'ie 8' ],
+                browsers: ['last 2 version', 'ie 6', 'ie 7', 'ie 8'],
                 cascade: true
             },
             dist: {
                 expand: true,
-                src: '.tmp/**/*.css'
+                src: '<%= settings.dir.dist %>/**/*.css'
             }
         },
 
@@ -38,14 +38,7 @@ module.exports = function (grunt) {
             // List of files that will be removed before the
             // build process is started
             all: [
-                '.tmp', // used by the `usemin` task
                 '<%= settings.dir.dist %>'
-            ],
-
-            // List of files no longer required after the build
-            // process is completed
-            tmp: [
-                '.tmp'  // used by the `usemin` task
             ]
         },
 
@@ -63,7 +56,7 @@ module.exports = function (grunt) {
             },
             livereload: {
                 options: {
-                    base: '<%= settings.dir.src %>',
+                    base: '<%= settings.dir.dist %>',
 
                     // Automatically open the webpage in the default browser
                     open: true
@@ -86,6 +79,21 @@ module.exports = function (grunt) {
                     '!css/*',
                     '!js/*'
                 ]
+            }
+        },
+
+        concat: {
+            css: {
+                src: [
+                    '<%= settings.dir.src %>/css/_normalize.css',
+                    '<%= settings.dir.src %>/css/_base.css',
+                    '<%= settings.dir.src %>/css/_utils.css',
+                    '<%= settings.dir.src %>/css/_components.css',
+                    '<%= settings.dir.src %>/css/_site.css',
+                    '<%= settings.dir.src %>/css/_mq.css',
+                    '<%= settings.dir.src %>/css/_print.css'
+                ],
+                dest: '<%= settings.dir.dist %>/css/main.css'
             }
         },
 
@@ -148,7 +156,7 @@ module.exports = function (grunt) {
                     jsCompressor: 'closure',
                     type: 'html'
                     /* there is no need to enable the other
-                       obtions, `htmlmin` takes care of that */
+                       options, `htmlmin` takes care of that */
                 }
             }
         },
@@ -180,16 +188,38 @@ module.exports = function (grunt) {
             }
         },
 
-        usemin: {
-            // List of files for which to update asset references
-            css: '<%= settings.dir.dist %>/css/*.css',
-            html: '<%= settings.dir.dist %>/index.html'
+        cssmin: {
+            minify: {
+                options: {
+                    compatibility: 'ie8',
+                    keepSpecialComments: '*'
+                },
+                files: {
+                    '<%= uncss.dist.dest %>': '<%= concat.css.dest %>'
+                }
+            }
+        },
+
+        uncss: {
+            options: {
+                ignoreSheets: [/fonts.googleapis/]
+            },
+            dist: {
+                src: '<%= settings.dir.dist %>/index.html',
+                dest: '<%= concat.css.dest %>'
+            }
         },
 
         useminPrepare: {
             // List of HTML files from which to process the usemin blocks
             // https://github.com/yeoman/grunt-usemin#blocks
             html: '<%= settings.dir.src %>/index.html'
+        },
+
+        usemin: {
+            // List of files for which to update asset references
+            css: '<%= settings.dir.dist %>/css/*.css',
+            html: '<%= settings.dir.dist %>/index.html'
         },
 
         watch: {
@@ -214,17 +244,17 @@ module.exports = function (grunt) {
 
     // build task
     grunt.registerTask('build', [
-        'clean:all',
+        'clean',
         'copy',
         'useminPrepare',
         'concat',
         'autoprefixer',
+        'uncss',
         'cssmin',
         'filerev',
         'usemin',
         'htmlcompressor',
-        'htmlmin',
-        'clean:tmp'
+        'htmlmin'
     ]);
 
     // default task
@@ -234,6 +264,13 @@ module.exports = function (grunt) {
     ]);
 
     grunt.registerTask('dev', [
+        'clean',
+        'copy',
+        'useminPrepare',
+        'concat',
+        'autoprefixer',
+        'filerev',
+        'usemin',
         'connect:livereload',
         'watch'
     ]);

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "grunt-htmlcompressor": "^0.1.10",
     "grunt-html-validation": "^0.1.16",
     "grunt-usemin": "^2.1.1",
+    "grunt-uncss": "^0.3.3",
     "load-grunt-tasks": "^0.4.0"
   },
   "engines": {

--- a/src/index.html
+++ b/src/index.html
@@ -6,17 +6,7 @@
         <meta name="description" content="HTML5 Boilerplate is a professional front-end template for building fast, robust, and adaptable web apps or sites. Spend more time developing and less time reinventing the wheel.">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Open+Sans:400,700">
-
-        <!-- build:css css/main.css -->
-        <link rel="stylesheet" href="css/_normalize.css">
-        <link rel="stylesheet" href="css/_base.css">
-        <link rel="stylesheet" href="css/_utils.css">
-        <link rel="stylesheet" href="css/_components.css">
-        <link rel="stylesheet" href="css/_site.css">
-        <link rel="stylesheet" href="css/_mq.css">
-        <link rel="stylesheet" href="css/_print.css">
-        <!-- endbuild -->
-
+        <link rel="stylesheet" href="css/main.css">
     </head>
     <body>
 


### PR DESCRIPTION
This saves ~30% of the minified, uncompressed CSS.

```
Before: 18.94 kB → 7.17 kB
After:  18.94 kB → 15.27 kB → 4.97 kB
```

Unfortunately, I couldn't access `usemin`'s concat object, so I had to specify the tasks manually. This is still something I'm generally looking into since it would simplify things a lot.
