### PR TITLE
Change to setting X-UA-Compatible in .htaccess

### DIFF
--- a/src/.htaccess
+++ b/src/.htaccess
@@ -38,17 +38,15 @@ ErrorDocument 404 /404.html
 # ------------------------------------------------------------------------------
 
 # Force Internet Explorer to render pages in the highest available
-# mode in the various cases when it may not.
+# mode in the various cases when it may not. Only for HTML documents.
 # https://hsivonen.fi/doctype/#ie8
 
-<IfModule mod_headers.c>
-    Header set X-UA-Compatible "IE=edge"
-    # `mod_headers` cannot match based on the content-type, however, this header
-    # should be send only for HTML documents and not for the other resources
-    <FilesMatch "\.(appcache|atom|crx|css|cur|eot|f4[abpv]|flv|gif|htc|ico|jpe?g|js|json(ld)?|m4[av]|manifest|map|mp4|oex|og[agv]|opus|otf|pdf|png|rdf|rss|safariextz|svgz?|swf|tt[cf]|txt|vcf|vtt|webapp|web[mp]|woff|xml|xpi)$">
-        Header unset X-UA-Compatible
-    </FilesMatch>
-</IfModule>
+<FilesMatch "\.(htm|html|php)$">
+    <IfModule mod_headers.c>
+        BrowserMatch MSIE ie
+        Header set X-UA-Compatible "IE=Edge" env=ie
+    </IfModule>
+</FilesMatch>
 
 
 # ##############################################################################


### PR DESCRIPTION
Should be more efficient to match files -> set header, rather than set header -> match files -> unset (and fewer file types to keep track of). Code taken from http://www.validatethis.co.uk/tag/x-ua-compatible/
