### PR TITLE
Get rid of outdated references to jQuery

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -20,7 +20,6 @@
     "sub": true,
 
     "browser": true,
-    "jquery": true,
     "node": true
 
 }

--- a/src/humans.txt
+++ b/src/humans.txt
@@ -20,6 +20,6 @@
 # TECHNOLOGY COLOPHON
 
     CSS3, HTML5
-    Gulp, HTML5 Boilerplate, jQuery, Normalize.css
+    Gulp, HTML5 Boilerplate, Normalize.css
 
     Source: https://github.com/h5bp/html5boilerplate.com


### PR DESCRIPTION
Two little things forgotten with https://github.com/h5bp/html5boilerplate.com/commit/56ca846822a7e7c746228491397d70747f1326eb:
- Get rid of the `jquery` JSHint option.
- Get rid of the jQuery mention in `humans.txt`
