### PR TITLE
Remove sites not using h5bp anymore

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -131,12 +131,9 @@
                 <a href="http://data.nasa.gov/">NASA</a>,
                 <a href="http://www.nikeskateboarding.com/">Nike</a>,
                 <a href="http://www.barackobama.com/">Barack Obama</a>,
-                <a href="http://a-class.mercedes-benz.com/">Mercedes-Benz</a>,
                 <a href="http://www.itv.com/news/">ITV News</a>,
-                <a href="http://www.astuteclass.com/">BAE Systems</a>,
                 <a href="http://creativecommons.org/">Creative Commons</a>,
                 <a href="http://auspost.com.au/">Australia Post</a>,
-                <a href="http://www.ew.com/">Entertainment Weekly</a>,
                 <a href="http://www.racinggreen.co.uk/">Racing Green</a>,
                 and
                 <a href="https://github.com/h5bp/html5-boilerplate/wiki/sites">many more</a>.


### PR DESCRIPTION
These sites don't seem to be using HTML5 Boilerplate anymore.