### PR TITLE
Added autoprefixer to package.json and integrated autoprefixer into the ...

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -87,9 +87,9 @@ gulp.task('copy:misc', function () {
 
 gulp.task('generate:main.css', function () {
     return gulp.src(dirs.src + '/css/index.css')
-            .pipe(plugins.rework(reworkSuit({
-                browsers: supportedBrowsers
-            })))
+            .pipe(plugins.rework(reworkSuit(
+            )))
+            .pipe(plugins.autoprefixer({browsers: supportedBrowsers}))
             .pipe(plugins.cssBase64())
             .pipe(plugins.uncss({
                 html: [dirs.src + '/index.html']

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "browser-sync": "^2.3.1",
     "del": "^1.0.0",
     "gulp": "^3.8.10",
+    "gulp-autoprefixer": "^2.1.0",
     "gulp-css-base64": "^1.3.1",
     "gulp-csso": "^1.0.0",
     "gulp-htmlmin": "^1.1.1",


### PR DESCRIPTION
Thanks for making this site and the HTML5Boilerplate project.  Both are brilliant.  

It looks like `reworkSuit` is used only to inline `normalize.css` css.  Consider using rework-npm directly instead.  