### PR TITLE
Fixing links and general housekeeping

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     }
   },
   "engines": {
-    "node": ">=4",
+    "node": ">=6",
     "npm": ">=3"
   },
   "private": true,

--- a/src/css/_base.css
+++ b/src/css/_base.css
@@ -41,7 +41,7 @@ a:active {
 
 /*
  * Remove the gap between images and the bottom of their containers:
- * h5bp.com/i/440
+ * https://github.com/h5bp/html5-boilerplate/issues/440
  */
 
 img {

--- a/src/css/_print.css
+++ b/src/css/_print.css
@@ -7,7 +7,7 @@
     * {
         background-color: transparent !important;
         box-shadow:none !important;
-        color: #000 !important; /* Black prints faster: h5bp.com/s */
+        color: #000 !important; /* Black prints faster */
         text-shadow: none !important;
     }
 
@@ -23,7 +23,7 @@
     }
 
     thead {
-        display: table-header-group; /* h5bp.com/t */
+        display: table-header-group; /* http://css-discuss.incutio.com/wiki/Printing_Tables */
     }
 
     tr,

--- a/src/index.html
+++ b/src/index.html
@@ -7,11 +7,12 @@
     <meta name="description" content="HTML5 Boilerplate is a professional front-end template for building fast, robust, and adaptable web apps or sites. Spend more time developing and less time reinventing the wheel.">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="apple-touch-icon" href="icon.png">
+    <link href="https://fonts.gstatic.com" rel="preconnect" crossorigin>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:400,700">
     <link rel="manifest" href="site.webmanifest">
     <meta name="twitter:card" content="summary">
     <meta name="twitter:site" content="@h5bp">
-    <meta name="twitter:url" content="https://html5boilerplate.com/t">
+    <meta name="twitter:url" content="https://html5boilerplate.com/">
     <meta name="twitter:title" content="HTML5 ★ BOILERPLATE">
     <meta name="twitter:description" content="The web’s most popular front-end template which helps you build fast, robust, and adaptable web apps or sites.">
     <meta name="twitter:image" content="https://html5boilerplate.com/icon.png">

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -148,7 +148,7 @@
     // -----------------------------------------------------------------
 
     // Tweet Buttons
-    // https://dev.twitter.com/docs/tweet-button
+    // https://dev.twitter.com/web/tweet-button
 
     function loadTweetButtons() {
         /* jshint ignore:start */


### PR DESCRIPTION
- Add link preconnect for Google Fonts to speed up font display time by approx 100ms REF: https://www.cdnplanet.com/blog/faster-google-webfonts-preconnect/
- Fix Twitter Dev link
- Fix typo in Twitter link in meta tag in `head`
- Removed dead H5BP.com shortlinks (instead linked to the final location)
- Update Node Requirement to >=6 to exclude unsupported v4/v5.
