### PR TITLE
Adds short_name, lang and theme_color to webmanifest

### DIFF
--- a/src/site.webmanifest
+++ b/src/site.webmanifest
@@ -1,5 +1,8 @@
 {
     "name": "HTML5 Boilerplate",
+    "short_name": "H5BP",
+    "lang": "en",
+    "theme_color": "#E08524",
     "description": "HTML5 Boilerplate is a professional front-end template for building fast, robust, and adaptable web apps or sites.",
     "icons": [{
         "src": "icon.png",


### PR DESCRIPTION
Note: `short_name` is required for titles longer than 12 characters

REF:
https://developers.google.com/web/fundamentals/app-install-banners/
https://developers.google.com/web/fundamentals/web-app-manifest/